### PR TITLE
Feature/MAT-743 gitleaks automation

### DIFF
--- a/.github/workflows/gitleaks_github_actions.yml
+++ b/.github/workflows/gitleaks_github_actions.yml
@@ -1,0 +1,28 @@
+name: Github Secrets Scanner
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      REPO: https://github.com/MeasureAuthoringTool/mat-tomcat
+      REMOTE_EXCLUDES_URL: https://github.com/casey-erdmann/bmat-gitleaks-automation/blob/master/mat-tomcat/gitleaks.toml
+      GITLEAKS_VERSION: v3.0.3
+    steps:
+    - name: Execute Gitleaks
+      run: |
+        wget ${REMOTE_EXCLUDES_URL} -O gitleaks.toml
+        wget https://github.com/zricethezav/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks-linux-amd64 -O gitleaks
+        chmod +x gitleaks
+        echo ${GITHUB_SHA}
+        echo "gitleaks --repo=${REPO} -v --pretty --redact --commit=${GITHUB_SHA} --config=gitleaks.toml"
+        ./gitleaks --repo=${REPO} -v --pretty --redact --commit=${GITHUB_SHA} --config=gitleaks.toml
+    - name: Slack notification
+      if: failure()
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      uses: Ilshidur/action-slack@master
+      with:
+        args: 'Potential Secrets found in: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }}. Link to build with full gitleaks output: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }}/checks'

--- a/.github/workflows/gitleaks_github_actions.yml
+++ b/.github/workflows/gitleaks_github_actions.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REPO: https://github.com/MeasureAuthoringTool/mat-tomcat
-      REMOTE_EXCLUDES_URL: https://github.com/casey-erdmann/bmat-gitleaks-automation/blob/master/mat-tomcat/gitleaks.toml
+      REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/casey-erdmann/bmat-gitleaks-automation/master/mat-tomcat/gitleaks.toml
       GITLEAKS_VERSION: v3.0.3
     steps:
     - name: Execute Gitleaks


### PR DESCRIPTION
This change adds an automated scanner that runs a gitleaks scan on push of any branch. This scan will trigger an alert to the security team if any sensitive looking information is found.

This works by adding a github action that retrieves a slack integration, a copy of the gitleaks binary, and a custom rules list that is maintained by the MAT Security Engineer to help fine tune false positives. This will not only trigger on push but will also be made available as an optional status check in PRs as an option to help further prevent sensitive data from being merged in further.