### PR TITLE
Upgrade gitleaks to v4.3.1 and point config to SB repo

### DIFF
--- a/.github/workflows/gitleaks_github_actions.yml
+++ b/.github/workflows/gitleaks_github_actions.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REPO: https://github.com/MeasureAuthoringTool/mat-tomcat
-      REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/casey-erdmann/bmat-gitleaks-automation/master/mat-tomcat/gitleaks.toml
-      GITLEAKS_VERSION: v3.0.3
+      REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/semanticbits/bmat-gitleaks-automation/master/mat-tomcat/gitleaks.toml
+      GITLEAKS_VERSION: v4.3.1
     steps:
     - name: Execute Gitleaks
       run: |


### PR DESCRIPTION
This PR upgrades our gitleaks automation to the latest version and points the config to our new SB bmat gitleaks config repo.